### PR TITLE
Bump bootstrap from 3.3.7 to 3.4.1 in /Vidly

### DIFF
--- a/Vidly/packages.config
+++ b/Vidly/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net461" />
-  <package id="bootstrap" version="3.3.7" targetFramework="net461" />
+  <package id="bootstrap" version="3.4.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="jQuery" version="3.3.1" targetFramework="net461" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net461" />


### PR DESCRIPTION
Bumps bootstrap from 3.3.7 to 3.4.1.

Signed-off-by: dependabot[bot] <support@github.com>